### PR TITLE
Test commits using travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: generic
+sudo: required
+dist: trusty
+before_install:
+  - bash <(curl -sS https://nixos.org/nix/install)
+  - source $HOME/.nix-profile/etc/profile.d/nix.sh
+  - sudo mkdir /etc/nix
+  - sudo sh -c 'echo "build-max-jobs = 4" > /etc/nix/nix.conf'
+install:
+  - nix-shell -p elmPackages.elm --run "elm package install -y"
+script:
+  - nix-shell -p elmPackages.elm --run "elm make src/UrlParser.elm"


### PR DESCRIPTION
I'm using [Nix, the functional package manager](http://nixos.org/nix/) to install Elm using binaries.

Here's the report travis-ci generates: https://travis-ci.org/domenkozar/url-parser/builds/133358687

Let me know if this discussion should take place elsewhere. cc @evancz 
