### PR TITLE
Fix oneOf stopping early on partial matches

### DIFF
--- a/src/UrlParser.elm
+++ b/src/UrlParser.elm
@@ -268,8 +268,16 @@ oneOfHelp choices chunks formatter =
         Err _ ->
           oneOfHelp otherParsers chunks formatter
 
-        Ok answerPair ->
-          Ok answerPair
+        Ok (chunks', result) ->
+          case chunks'.rest of
+            [] ->
+              Ok (chunks', result)
+
+            [""] ->
+              Ok (chunks', result)
+
+            _ ->
+              oneOfHelp otherParsers chunks formatter
 
 
 {-| Customize an existing parser. Perhaps you want a parser that matches any


### PR DESCRIPTION
Parsing using `oneOf` stops early when it encounters a partial match. I believe this is unintended behavior. For example,

``` elm
type Page
  = User String
  | Entry String String

pageParser =
  oneOf
    [ format User string
    , format Entry (string </> string)
    ]

parse identity pageParser "username/entryname"
```

results in

``` elm
Err "The parser worked, but /entryname was left over."
```

instead of

``` elm
Ok (Entry "username" "entryname")
```

The change makes `oneOf` check for partial matches just as `parse` does.
