### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ To see an example of this library paired with `elm-lang/navigation`, check out t
 I first saw this general idea in Chris Done&rsquo;s [formatting][] library. Based on that, Noah and I outlined the API you see in this library. Noah then found Rudi Grinberg&rsquo;s [post][] about type safe routing in OCaml. It was exactly what we were going for. We had even used the names `s` and `(</>)` in our draft API! In the end, we ended up using the &ldquo;final encoding&rdquo; of the EDSL that had been left as an exercise for the reader. Very fun to work through! 😃
 
 [formatting]: http://chrisdone.com/posts/formatting
-[post]: http://rgrinberg.com/blog/2014/12/13/primitive-type-safe-routing/
+[post]: http://rgrinberg.com/posts/primitive-type-safe-routing/


### PR DESCRIPTION
This fixes the broken link to Rudi Grinberg's "Type Safe Routing - Baby Steps" blog post
