### PR TITLE
Allow parsing remaining segments

### DIFF
--- a/src/UrlParser.elm
+++ b/src/UrlParser.elm
@@ -1,5 +1,5 @@
 module UrlParser exposing
-  ( Parser, string, int, s
+  ( Parser, string, int, s, remainingSegments
   , (</>), map, oneOf, top, custom
   , QueryParser, (<?>), stringParam, intParam, customParam
   , parsePath, parseHash
@@ -8,7 +8,7 @@ module UrlParser exposing
 {-|
 
 # Primitives
-@docs Parser, string, int, s
+@docs Parser, string, int, s, remainingSegments
 
 # Path Parses
 @docs (</>), map, oneOf, top, custom
@@ -126,6 +126,15 @@ custom tipe stringToSomething =
           Err msg ->
             []
 
+
+{-| Parse the remaining segments as strings:
+
+    s "foo" </> remainingSegments -- parses /foo and /foo/bar/baz
+-}
+remainingSegments : Parser (List String -> a) a
+remainingSegments =
+    Parser <| \{ visited, unvisited, params, value } ->
+        [ State ((List.reverse unvisited) ++ visited) [] params (value unvisited) ]
 
 
 -- COMBINING PARSERS
@@ -245,7 +254,6 @@ oneOf parsers =
 top : Parser a a
 top =
   Parser <| \state -> [state]
-
 
 
 -- QUERY PARAMETERS

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -24,6 +24,7 @@ testParsing =
     , parserTest "Users" "users" (UsersRoutes UsersRoute)
     , parserTest "User" "users/2" (UsersRoutes (UserRoute 2))
     , parserTest "Edit" "users/2/edit" (UsersRoutes (UserEditRoute 2))
+    , parserTest "Rest" "rest/foo/bar/baz" (RestRoute ["foo", "bar", "baz"])
     ]
 
 
@@ -66,6 +67,7 @@ type MainRoute
     | AboutRoute
     | TokenRoute String
     | UsersRoutes UserRoute
+    | RestRoute (List String)
     | NotFoundRoute
 
 
@@ -89,6 +91,7 @@ mainMatchers =
     , map AboutRoute (s "about")
     , map TokenRoute (s "token" </> string)
     , map UsersRoutes (s "users" </> (oneOf usersMatchers))
+    , map RestRoute (s "rest" </> remainingSegments)
     ]
 
 


### PR DESCRIPTION
This adds a parser for returning the remaining segments as a list of strings.

It's extremely useful in dynamic routing situations, where the routing reflects a file system hierarchy - I found no way to achieve such behaviour with the already present functions.