### PR TITLE
Fix typo in documentation comment

### DIFF
--- a/src/UrlParser.elm
+++ b/src/UrlParser.elm
@@ -205,7 +205,7 @@ mapHelp func {visited, unvisited, params, value} =
         [ map Search  (s "search" </> string)
         , map Blog    (s "blog" </> int)
         , map User    (s "user" </> string)
-        , map Comment (s "user" </> string </> "comments" </> int)
+        , map Comment (s "user" </> string </> s "comments" </> int)
         ]
 
     parsePath route location


### PR DESCRIPTION
Without calling the s function you will get a type error as you won't have a Parser.

The newline at the  end was added by github.