### PR TITLE
Decode path segments before parsing

### DIFF
--- a/src/UrlParser.elm
+++ b/src/UrlParser.elm
@@ -387,12 +387,23 @@ parseHelp states =
 
 splitUrl : String -> List String
 splitUrl url =
-  case String.split "/" url of
-    "" :: segments ->
-      segments
+  List.map decodeSegment <|
+    case String.split "/" url of
+      "" :: segments ->
+        segments
 
-    segments ->
-      segments
+      segments ->
+        segments
+
+
+decodeSegment : String -> String
+decodeSegment segment =
+  case Http.decodeUri segment of
+    Just decoded ->
+      decoded
+
+    Nothing ->
+      segment
 
 
 parseParams : String -> Dict String String


### PR DESCRIPTION
Path (and hash) segments are not decoded, in contrast to query parameters. Additionally, some browsers provide `location.hash` already decoded (chrome) and some do not (safari, firefox). For example,

```
localhost/#some/path/in/español
```

will reach a parser as `espa%C3%B1ol` under safari, but `español` under chrome.

This change decodes the hash or path at segment level. Resolves #32.

This still allows for encoded `/` slashes, in case that that is in use somewhere. For example,

```
localhost/#lang/espa%C3%B1ol%2Fspanish
```

would always result in the segments `lang` and `español/spanish`.

In the case of `Http.decodeUri` failing to parse a segment, the original segment is used.
