### PR TITLE
Update reference to union types to custom types

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ route =
 -- parseHash route { ... , hash = "#/blog" }       == Nothing
 ```
 
-Notice that we are turning URLs into nice [union types](https://guide.elm-lang.org/types/union_types.html), so we can use `case` expressions to work with them in a nice way.
+Notice that we are turning URLs into nice [custom types](https://guide.elm-lang.org/types/custom_types.html), so we can use `case` expressions to work with them in a nice way.
 
 Check out the `examples/` directory of this repo to see this in use with `elm-lang/navigation`.
 


### PR DESCRIPTION
I've updated the link and text for the reference to _union types_ to the new preferred term _custom types_. It appears that the previous link was dead so this should help improve those reading the library docs however I would suggest considering creating a dummy page for [union types](https://guide.elm-lang.org/types/custom_types.html) to point to the new _custom types_ documentation or just do it as a redirect for those who may have bookmarks to this documentation resource.